### PR TITLE
Fix PlayerHearthstone in Overwatch Stream Metadata

### DIFF
--- a/TwitchLib/Models/API/Helix/StreamsMetadata/Overwatch.cs
+++ b/TwitchLib/Models/API/Helix/StreamsMetadata/Overwatch.cs
@@ -8,6 +8,6 @@ namespace TwitchLib.Models.API.Helix.StreamsMetadata
 {
     public class Overwatch
     {
-        public PlayerHearthstone Broadcaster { get; protected set; }
+        public PlayerOverwatch Broadcaster { get; protected set; }
     }
 }


### PR DESCRIPTION
Issue prevents stream metadata for overwatch working correctly.