### PR TITLE
Noticed that not all events inherit EventArgs

### DIFF
--- a/TwitchLib/Events/Client/OnGiftedSubscriptionArgs.cs
+++ b/TwitchLib/Events/Client/OnGiftedSubscriptionArgs.cs
@@ -1,8 +1,9 @@
-﻿using TwitchLib.Models.Client;
+﻿using System;
+using TwitchLib.Models.Client;
 
 namespace TwitchLib.Events.Client
 {
-    public class OnGiftedSubscriptionArgs
+    public class OnGiftedSubscriptionArgs : EventArgs
     {
         public GiftedSubscription GiftedSubscription;
     }

--- a/TwitchLib/Events/Client/OnLogArgs.cs
+++ b/TwitchLib/Events/Client/OnLogArgs.cs
@@ -2,7 +2,7 @@
 
 namespace TwitchLib.Events.Client
 {
-    public class OnLogArgs
+    public class OnLogArgs : EventArgs
     {
         public string BotUsername;
         public string Data;

--- a/TwitchLib/Events/Client/OnRaidNotificationArgs.cs
+++ b/TwitchLib/Events/Client/OnRaidNotificationArgs.cs
@@ -1,8 +1,9 @@
-﻿using TwitchLib.Models.Client;
+﻿using System;
+using TwitchLib.Models.Client;
 
 namespace TwitchLib.Events.Client
 {
-    public class OnRaidNotificationArgs
+    public class OnRaidNotificationArgs : EventArgs
     {
         public RaidNotification RaidNotificaiton;
     }

--- a/TwitchLib/Events/Client/OnRitualNewChatterArgs.cs
+++ b/TwitchLib/Events/Client/OnRitualNewChatterArgs.cs
@@ -1,8 +1,9 @@
-﻿using TwitchLib.Models.Client;
+﻿using System;
+using TwitchLib.Models.Client;
 
 namespace TwitchLib.Events.Client
 {
-    public class OnRitualNewChatterArgs
+    public class OnRitualNewChatterArgs : EventArgs
     {
         public RitualNewChatter RitualNewChatter;
     }

--- a/TwitchLib/Events/Client/OnUnaccountedForArgs.cs
+++ b/TwitchLib/Events/Client/OnUnaccountedForArgs.cs
@@ -1,6 +1,7 @@
-﻿namespace TwitchLib.Events.Client
+﻿using System;
+namespace TwitchLib.Events.Client
 {
-    public class OnUnaccountedForArgs
+    public class OnUnaccountedForArgs : EventArgs
     {
         public string RawIRC { get; set; }
         public string Location { get; set; }


### PR DESCRIPTION
Noticed that some client events don't inherit EventArgs. Do not know if this was on purpose, yet I updated each file to follow the standard that other events have set. Also keeping it consistent over all events.