### PR TITLE
Fix link to TwitchLib.Extension Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ namespace Example
 For a complete list of TwitchPubSub functionality, click <a href="https://swiftyspiffy.com/TwitchLib/PubSub/index.html" target="_blank">here</a>
 
 #### TwitchLib.Extension
-See the Extension README <a href="https://github.com/swiftyspiffy/TwitchLib/tree/master/TwitchLib.Extension" target="_blank">here</a>.
+See the Extension README <a href="https://github.com/TwitchLib/TwitchLib.Extension" target="_blank">here</a>.
 
 ## Examples, Applications, Community Work, and Projects
 


### PR DESCRIPTION
Old link went into the void