### PR TITLE
Add note about scopes in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ namespace TestConsole
 	
         public Bot()
         {
+            // Make sure your OAuth token has the chat:read and chat:edit scopes.
             ConnectionCredentials credentials = new ConnectionCredentials("twitch_username", "access_token");
 	    var clientOptions = new ClientOptions
                 {


### PR DESCRIPTION
Add a comment to direct new clients of the library to make sure they have chat:read and chat:edit scopes in their OAuth keys. Maybe it'll save someone some time and headache down the line.